### PR TITLE
Upgrade to OrchardCore 3.0.1 / .NET 10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,12 @@ jobs:
         value: $[ dependencies.Init.outputs['package.version'] ]
     steps:
 
+      - task: UseDotNet@2
+        displayName: Install .NET SDK (global.json)
+        inputs:
+          packageType: 'sdk'
+          useGlobalJson: true
+
       - task: DotNetCoreCLI@2
         displayName: Restore NuGet packages
         inputs:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.200",
+    "rollForward": "latestFeature"
+  }
+}

--- a/samples/Griesoft.OrchardCore.ReCaptcha.Sample/Griesoft.OrchardCore.ReCaptcha.Sample.csproj
+++ b/samples/Griesoft.OrchardCore.ReCaptcha.Sample/Griesoft.OrchardCore.ReCaptcha.Sample.csproj
@@ -19,13 +19,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.0" Condition="'$(RazorRuntimeCompilation)' == 'true'" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.11" Condition="'$(RazorRuntimeCompilation)' == 'true'" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="2.2.1" />
+    <PackageReference Include="OrchardCore.Application.Cms.Targets" Version="3.0.1" />
+    <!-- Transitive pin: OrchardCore 3.0.1 resolves AngleSharp 1.4.0 (GHSA-pgww-w46g-26qg, patched in 1.5.0). Remove once OrchardCore references a patched version. -->
+    <PackageReference Include="AngleSharp" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Drivers/RecaptchaInvisiblePartDisplayDriver.cs
+++ b/src/Drivers/RecaptchaInvisiblePartDisplayDriver.cs
@@ -65,7 +65,7 @@ namespace Griesoft.OrchardCore.ReCaptcha.Drivers
             part.ContentText = viewmodel.Content;
             part.TagType = viewmodel.TagType;
 
-            return Edit(part);
+            return Edit(part, context);
         }
     }
 }

--- a/src/Griesoft.OrchardCore.ReCaptcha.csproj
+++ b/src/Griesoft.OrchardCore.ReCaptcha.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -37,13 +37,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Griesoft.AspNetCore.ReCaptcha" Version="2.3.1" />
-		<PackageReference Include="OrchardCore.Module.Targets" Version="2.2.1" />
-		<PackageReference Include="OrchardCore.ContentManagement" Version="2.2.1" />
-		<PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="2.2.1" />
-		<PackageReference Include="OrchardCore.DisplayManagement" Version="2.2.1" />
-		<PackageReference Include="OrchardCore.Navigation.Core" Version="2.2.1" />
-		<PackageReference Include="OrchardCore.ResourceManagement" Version="2.2.1" />
-		<PackageReference Include="OrchardCore.Workflows.Abstractions" Version="2.2.1" />
+		<PackageReference Include="OrchardCore.Module.Targets" Version="3.0.1" />
+		<PackageReference Include="OrchardCore.ContentManagement" Version="3.0.1" />
+		<PackageReference Include="OrchardCore.ContentTypes.Abstractions" Version="3.0.1" />
+		<PackageReference Include="OrchardCore.DisplayManagement" Version="3.0.1" />
+		<PackageReference Include="OrchardCore.Navigation.Core" Version="3.0.1" />
+		<PackageReference Include="OrchardCore.ResourceManagement" Version="3.0.1" />
+		<PackageReference Include="OrchardCore.Workflows.Abstractions" Version="3.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/tests/Griesoft.OrchardCore.ReCaptcha.Tests.csproj
+++ b/tests/Griesoft.OrchardCore.ReCaptcha.Tests.csproj
@@ -8,15 +8,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/tests/Services/RecaptchaSettingsConfigurationTests.cs
+++ b/tests/Services/RecaptchaSettingsConfigurationTests.cs
@@ -77,7 +77,7 @@ namespace Griesoft.OrchardCore.ReCaptcha.Tests.Services
         private ISiteService CreateSiteServiceMock(string settingsSiteKey, string settingsSecretKey)
         {
             var siteMock = new Mock<ISite>();
-            siteMock.Setup(site => site.As<RecaptchaSettings>())
+            siteMock.Setup(site => site.GetOrCreate<RecaptchaSettings>())
                 .Returns(new RecaptchaSettings() { SiteKey = settingsSiteKey, SecretKey = settingsSecretKey });
             var siteServiceMock = new Mock<ISiteService>();
             siteServiceMock.Setup(service => service.GetSiteSettingsAsync())


### PR DESCRIPTION
Implements the OC 3.0.1 / .NET 10 upgrade per the analysis in #12.

Closes #12

## What changed

**Retarget & OC bump**
- `src` now targets `net10.0` only (dropped `net8.0` — OC 3.x requires .NET 10).
- All `OrchardCore.*` references bumped **2.2.1 → 3.0.1** (`Module.Targets`, `ContentManagement`, `ContentTypes.Abstractions`, `DisplayManagement`, `Navigation.Core`, `ResourceManagement`, `Workflows.Abstractions`), and `OrchardCore.Application.Cms.Targets` 2.2.1 → 3.0.1 in the sample host.
- Added `global.json` pinning the .NET SDK to **10.0.200+** (`rollForward: latestFeature`) per the 3.0.1 Roslyn 5.3 requirement.
- CI: added a `UseDotNet@2` step (honors `global.json`) so the `windows-latest` agent builds with the right SDK.

**Breaking-change fixes** (the audit predicted none; two small ones surfaced in practice)
- `RecaptchaInvisiblePartDisplayDriver.UpdateAsync` returned `Edit(part)` — the context-less overload no longer exists in OC 3, so it now returns `Edit(part, context)` like the V2/V3 drivers (this was also flagged as drift in #13, but it is a compile break on 3.0.1, so it lands here).
- Test mock updated from the obsolete `ISite.As<T>()` to `ISite.GetOrCreate<T>()` — in OC 3, `ISiteService.GetSettingsAsync<T>()` resolves through the new `ISite.GetOrCreate<T>()` instance method, so the old mock returned null settings (3 test failures) and raised CS0618.

**Other dependency updates** (per the audit table in #12)
- Sample: `Microsoft.AspNetCore.Authentication.OpenIdConnect` 9.0.0 → **10.0.11**, `Microsoft.Extensions.Http.Resilience` 9.6.0 → **10.9.0**, `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` 10.0.0 → **10.0.11**.
- Tests: `Microsoft.Extensions.Caching.Memory` 9.0.4 → **10.0.11**, `Microsoft.NET.Test.Sdk` 18.0.1 → **18.9.0**, `coverlet.collector` 6.0.4 → **10.0.1**, `xunit.runner.visualstudio` 3.1.5 → **4.0.0** (verified: 4.0.0 explicitly supports xunit v1/v2/v3, so this is safe while staying on xunit 2.9.3).
- Sample: pinned **AngleSharp 1.7.2** — OC 3.0.1 still resolves 1.4.0, which is vulnerable (GHSA-pgww-w46g-26qg, patched in 1.5.0). Comment in the csproj says to drop the pin once OC references a patched version.

## Verification
- `dotnet build -c Release` — clean, **0 warnings, 0 errors** (double build + full non-incremental rebuild).
- `dotnet test` — **4/4 passing** on net10.0.
- `dotnet list package --vulnerable --include-transitive` — **zero advisories** in all three projects (was 6 advisories incl. one High via OC 2.2.1).

## Intentionally not done
- **No Dependabot** — the `dependabot.yml` recommendation in #12 is deliberately skipped per Joonas's decision; no automated dependency monitoring was added.
- **#13 deferred** — it is a broad cleanup issue (deprecations, sealing, README, admin-theme markup, optional xunit v3 migration), not a low-risk fold-in; only its `Edit(part, context)` item landed here because OC 3 forces it. The xunit v3 migration stays with #13.
- **Admin "reveal icon" bug** untouched — separate ticket.

## Release steps after merge (maintainer)
- This is a **new major** (3.x for OC 3.x; dropping net8.0/OC 2.x is breaking for consumers): update the Azure DevOps `Package Versioning` variable group to `major=3, minor=0, patch=0`. Not doable from this environment (no DevOps org access).
- Smoke-test the sample per #12 (settings editor, three widgets/parts, both workflow tasks) before tagging.

Once published, this unblocks the OC 3 upgrades of Subway, mast-web, sax-web, and vibrava-web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
